### PR TITLE
Added direct ASM to MC converter using asm2mca.py and mca2mc.py

### DIFF
--- a/src/1_0/asm2mc.py
+++ b/src/1_0/asm2mc.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import subprocess
+
+def execute_commands(base_name):
+    asm_path = f"{base_name}.asm"
+    mca_path = f"{base_name}.mca"
+    mc_path = f"{base_name}.mc"
+
+    if not os.path.isfile(asm_path):
+        print(f"Error: The file '{asm_path}' does not exist.")
+        return
+
+    # | tail -n +15
+    def process_output(output, file_path):
+        lines = output.splitlines()
+        processed_output = "\n".join(lines[14:])
+        print(processed_output)
+        with open(file_path, 'w') as file:
+            file.write(processed_output)
+
+    # Execute the first command (asm2mca.py) and process its output
+    print(f"{mca_path}:")
+    command1 = [sys.executable, 'asm2mca.py', asm_path]
+    result1 = subprocess.run(command1, capture_output=True, text=True)
+    process_output(result1.stdout, mca_path)
+
+    print()
+    
+    # Execute the second command (mca2mc.py) and process its output
+    print(f"{mc_path}:")
+    command2 = [sys.executable, 'mca2mc.py', mca_path]
+    result2 = subprocess.run(command2, capture_output=True, text=True)
+    process_output(result2.stdout, mc_path)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: py to.py <base_name>")
+        sys.exit(1)
+
+    base_name = sys.argv[1].removesuffix(".asm")
+    execute_commands(base_name)

--- a/src/1_0/asm2mc.py
+++ b/src/1_0/asm2mc.py
@@ -35,7 +35,7 @@ def execute_commands(base_name):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: py to.py <base_name>")
+        print("Usage: py asm2mc.py <base_name>")
         sys.exit(1)
 
     base_name = sys.argv[1].removesuffix(".asm")

--- a/src/1_0/asm2mc.py
+++ b/src/1_0/asm2mc.py
@@ -4,8 +4,8 @@ import subprocess
 
 def execute_commands(base_name):
     asm_path = f"{base_name}.asm"
-    mca_path = f"{base_name}.mca"
-    mc_path = f"{base_name}.mc"
+    mca_path = f"{sys.argv[2]}.mca" if len(sys.argv) == 3 else f"{base_name}.mca"
+    mc_path = f"{sys.argv[2]}.mc" if len(sys.argv) == 3 else f"{base_name}.mc"
 
     if not os.path.isfile(asm_path):
         print(f"Error: The file '{asm_path}' does not exist.")
@@ -34,8 +34,8 @@ def execute_commands(base_name):
     process_output(result2.stdout, mc_path)
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: py asm2mc.py <base_name>")
+    if len(sys.argv) not in {2, 3}:
+        print("Usage: py asm2mc.py <base_name> [output_file]")
         sys.exit(1)
 
     base_name = sys.argv[1].removesuffix(".asm")


### PR DESCRIPTION
Po wykonaniu skryptu, zostaną wykonane pliki skryptów `asm2mca.py` oraz `mca2mc.py` z odpowiednimi argumentami, a w rezultacie zostaną utworzone 2 pliki: "nazwa.mca" i "nazwa.mc", a ich zawartość zwrócona w terminalu. Przy podaniu argumentu nazwy plików wyjściowych, oba te pliki uzyskają nazwę argumentu z odpowiednimi rozszerzeniami.
## Użycie:
```console
$ py asm2mc.py <nazwa pliku> [nazwa plików wyjściowych]
```
lub
```console
$ py asm2mc.py <nazwa pliku>.asm
```
## Przykładowe działanie:
### Plik `p1.asm`:
```asm
.data 100
x: 2
i: 0
.data 200
y: 4

.code 250
START: CPA x
       SUB y
       BRN TEST
       HLT
TEST:  CPA x
       STO i
       CPA y
       STO x
       CPA i
       STO y
       HLT
```

### Output:
```console
$ py asm2mc.py p1
p1.mca:
0100 00002
0101 00000
0200 00004
0250 CPA 0100
0251 SUB 0200
0252 BRN 0254
0253 HLT
0254 CPA 0100
0255 STO 0101
0256 CPA 0200
0257 STO 0100
0258 CPA 0101
0259 STO 0200
0260 HLT

p1.mc:
0100 00002 ; 
0101 00000 ;
0200 00004 ;
0250 10100 ;
0251 40200 ;
0252 70254 ;
0253 00000 ;
0254 10100 ;
0255 20101 ;
0256 10200 ;
0257 20100 ;
0258 10101 ;
0259 20200 ;
0260 00000 ;
```